### PR TITLE
Fix post query

### DIFF
--- a/src/main/java/com/yeoni/cock/controller/post/PostController.java
+++ b/src/main/java/com/yeoni/cock/controller/post/PostController.java
@@ -26,8 +26,13 @@ public class PostController {
 
     @Operation(summary = "게시글 목록", description = "게시글 목록")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<PostResponse>>> findByBoardId(@PathVariable Long boardId) {
-        return ResponseEntity.ok(ApiResponse.success(postService.findByBoardId(boardId)));
+    public ResponseEntity<ApiResponse<List<PostResponse>>> findByBoardId(
+            @PathVariable Long boardId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String keyword) {
+        return ResponseEntity.ok(
+                ApiResponse.success(postService.findByBoardId(boardId, page, size, keyword)));
     }
 
     @Operation(summary = "게시글 상세", description = "게시글 상세")

--- a/src/main/java/com/yeoni/cock/mapper/PostMapper.java
+++ b/src/main/java/com/yeoni/cock/mapper/PostMapper.java
@@ -9,7 +9,11 @@ import java.util.Optional;
 
 @Mapper
 public interface PostMapper {
-    List<Post> findByBoardId(@Param("boardId") Long boardId);
+    List<Post> findByBoardId(
+            @Param("boardId") Long boardId,
+            @Param("offset") int offset,
+            @Param("limit") int limit,
+            @Param("keyword") String keyword);
     Optional<Post> findById(@Param("postId") Long postId);
     void save(@Param("post") Post post);
     void update(@Param("post") Post post);

--- a/src/main/java/com/yeoni/cock/service/PostService.java
+++ b/src/main/java/com/yeoni/cock/service/PostService.java
@@ -22,8 +22,9 @@ public class PostService {
     private final CommentService commentService;
 
     @Transactional(readOnly = true)
-    public List<PostResponse> findByBoardId(Long boardId) {
-        List<Post> posts = postMapper.findByBoardId(boardId);
+    public List<PostResponse> findByBoardId(Long boardId, int page, int size, String keyword) {
+        int offset = (page - 1) * size;
+        List<Post> posts = postMapper.findByBoardId(boardId, offset, size, keyword);
         return posts.stream()
                 .map(this::convertToResponse)
                 .collect(Collectors.toList());

--- a/src/main/resources/mapper/PostMapper.xml
+++ b/src/main/resources/mapper/PostMapper.xml
@@ -22,12 +22,15 @@
     <select id="findByBoardId" resultMap="postResultMap">
         SELECT *
         FROM tb_post p
-        LEFT JOIN tb_post_report r
-          ON p.post_id = r.post_id AND r.reporter_id = #{post.authorId}
-        WHERE r.report_id IS NULL
+        WHERE p.board_id = #{boardId}
           AND p.is_deleted = 0
           AND p.status = 'ACTIVE'
-        ORDER BY is_notice DESC, post_id DESC
+        <if test="keyword != null and keyword != ''">
+          AND (p.title LIKE CONCAT('%', #{keyword}, '%')
+               OR p.content LIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+        ORDER BY p.is_notice DESC, p.post_id DESC
+        LIMIT #{limit} OFFSET #{offset}
     </select>
 
     <select id="findById" resultMap="postResultMap">


### PR DESCRIPTION
## Summary
- filter posts by board ID directly in `findByBoardId`
- remove join to tb_post_report and keep active posts only
- add pagination and keyword search for posts

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_6840d54bf398832288b156ddff87cdad