### PR TITLE
Fix poll results mapping and post update

### DIFF
--- a/src/main/java/com/yeoni/cock/domain/dto/post/PostResponse.java
+++ b/src/main/java/com/yeoni/cock/domain/dto/post/PostResponse.java
@@ -22,7 +22,7 @@ public class PostResponse {
     private String status;
     private String createdBy;
     private LocalDateTime createdAt;
-    private Long updatedBy;
+    private String updatedBy;
     private LocalDateTime updatedAt;
     private List<CommentResponse> comments;
 } 

--- a/src/main/java/com/yeoni/cock/domain/entity/PollResult.java
+++ b/src/main/java/com/yeoni/cock/domain/entity/PollResult.java
@@ -13,4 +13,6 @@ public class PollResult {
     private Long itemId;
     private String userId;
     private LocalDateTime votedAt;
-} 
+    private String itemDescription;
+    private Integer itemOrder;
+}

--- a/src/main/java/com/yeoni/cock/domain/entity/Post.java
+++ b/src/main/java/com/yeoni/cock/domain/entity/Post.java
@@ -21,6 +21,6 @@ public class Post {
     private boolean isDeleted;
     private String createdBy;
     private LocalDateTime createdAt;
-    private Long updatedBy;
+    private String updatedBy;
     private LocalDateTime updatedAt;
 } 

--- a/src/main/java/com/yeoni/cock/service/PollResultService.java
+++ b/src/main/java/com/yeoni/cock/service/PollResultService.java
@@ -106,6 +106,8 @@ public class PollResultService {
         response.setItemId(result.getItemId());
         response.setUserId(result.getUserId());
         response.setVotedAt(result.getVotedAt());
+        response.setItemDescription(result.getItemDescription());
+        response.setItemOrder(result.getItemOrder());
         return response;
     }
-} 
+}

--- a/src/main/java/com/yeoni/cock/service/PostService.java
+++ b/src/main/java/com/yeoni/cock/service/PostService.java
@@ -70,7 +70,7 @@ public class PostService {
         post.setContent(request.getContent());
         post.setSecret(request.isSecret());
         post.setNotice(request.isNotice());
-        post.setUpdatedBy(Long.parseLong(userId));
+        post.setUpdatedBy(userId);
 
         postMapper.update(post);
     }

--- a/src/main/resources/mapper/PollResultMapper.xml
+++ b/src/main/resources/mapper/PollResultMapper.xml
@@ -7,6 +7,8 @@
         <result property="itemId" column="item_id"/>
         <result property="userId" column="user_id"/>
         <result property="votedAt" column="voted_at"/>
+        <result property="itemDescription" column="item_description"/>
+        <result property="itemOrder" column="item_order"/>
     </resultMap>
 
     <select id="findByPollId" resultMap="pollResultResultMap">


### PR DESCRIPTION
## Summary
- include item metadata in PollResult entity
- expose item description/order in PollResultService responses
- map new columns in PollResultMapper.xml
- store userId directly for Post updates

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6840d3ea49908322bc7d5889a73228aa